### PR TITLE
Fix typo in zettelkasten post

### DIFF
--- a/content/posts/2020/07/17/my-second-brain-zettelkasten/index.mdx
+++ b/content/posts/2020/07/17/my-second-brain-zettelkasten/index.mdx
@@ -74,7 +74,7 @@ find all the artifacts for code snippets and word formatting
 throughout.
 
 Getting my data out of Notion was straightforward enough but what I
-was left with was a but of a mess. Because of the nesting you were
+was left with was a bit of a mess. Because of the nesting you were
 able to do with pages in pages the export was a mess of files with
 hashes appended to them which is going to take a while to untangle.
 


### PR DESCRIPTION
As you have an 'Edit on GitHub' link I thought I might as well fix the typo 😄